### PR TITLE
Initial play animation branch commit.

### DIFF
--- a/src/BasicBehaveEngine/BasicBehaveEngine.ts
+++ b/src/BasicBehaveEngine/BasicBehaveEngine.ts
@@ -15,6 +15,7 @@ import {WaitAll} from "./nodes/flow/WaitAll";
 import {WhileLoop} from "./nodes/flow/WhileLoop";
 import {WorldGet} from "./nodes/world/WorldGet";
 import {WorldSet} from "./nodes/world/WorldSet";
+import {PlayAnimation} from "./nodes/world/PlayAnimation";
 import {WorldAnimateTo} from "./nodes/world/WorldAnimateTo";
 import {Receive} from "./nodes/customEvent/Receive";
 import {Send} from "./nodes/customEvent/Send";
@@ -124,6 +125,11 @@ export class BasicBehaveEngine implements IBehaveEngine {
         this.jsonPtrTrie.addPath(jsonPtr, getterCallback, setterCallback, typeName);
     }
 
+    public registerEngineCallback = (path: string, callback: (value: any, onComplete: ()=> void) => void) => {
+        console.log(`registering engine callback ${path}`);
+        this.jsonPtrTrie.addEngineCallback(path, callback);
+    }
+
     public isValidJsonPtr = (jsonPtr: string): boolean => {
         return this.jsonPtrTrie.isPathValid(jsonPtr);
     }
@@ -134,6 +140,10 @@ export class BasicBehaveEngine implements IBehaveEngine {
 
     public getPathtypeName = (path: string) => {
         return this.jsonPtrTrie.getPathTypeName(path);
+    }
+
+    public runEngineCallback(path: string, value: any, onComplete: ()=> void) { 
+        this.jsonPtrTrie.runEngineCallback(path, value, onComplete);
     }
 
     public setPathValue = (path: string, value: any) => {
@@ -241,6 +251,7 @@ export class BasicBehaveEngine implements IBehaveEngine {
         this.registerBehaveEngineNode("flow/whileLoop", WhileLoop);
         this.registerBehaveEngineNode("world/get", WorldGet);
         this.registerBehaveEngineNode("world/set", WorldSet);
+        this.registerBehaveEngineNode("world/playAnimation", PlayAnimation);
         this.registerBehaveEngineNode("world/animateTo", WorldAnimateTo);
         this.registerBehaveEngineNode("math/abs", AbsoluteValue);
         this.registerBehaveEngineNode("customEvent/receive", Receive);

--- a/src/BasicBehaveEngine/IBehaveEngine.ts
+++ b/src/BasicBehaveEngine/IBehaveEngine.ts
@@ -42,6 +42,14 @@ export interface IBehaveEngine {
     ) => void;
 
     /**
+     * Register a JSON pointer along with callback functions for getting and setting its value.
+     * @param path - The JSON pointer string.
+     * @param value - The value to use for the engine callback
+     * @param onComplete - the function to run whenever this is finished
+     */
+   registerEngineCallback: (path: string, callback:(value: any, onComplete: ()=> void) => void) => void;
+
+    /**
      * Register a Behave Engine node type along with its corresponding class.
      * @param type - The type of the Behave Engine node.
      * @param behaveEngineNode - The class representing the Behave Engine node.

--- a/src/BasicBehaveEngine/JsonPtrTrie.ts
+++ b/src/BasicBehaveEngine/JsonPtrTrie.ts
@@ -10,6 +10,7 @@ class TrieNode {
     trieNodeType: TrieNodeType;
     setterCallback: ((path: string, value: any) => void) | undefined;
     getterCallback: ((path: string) => any) | undefined;
+    engineCallbacks: Map<string, (value: any, onComplete: ()=> void) => void> = new Map<string, (value: any, onComplete: ()=> void) => void>();
     typeName: string | undefined;
 
 
@@ -25,6 +26,11 @@ export class JsonPtrTrie {
 
     constructor() {
         this.root = new TrieNode(TrieNodeType.ROOT);
+    }
+
+    public addEngineCallback(path: string, callback: (value: any, onComplete: ()=> void) => void) {
+        console.log(`Adding engine callback for: ${path}`);
+        this.root.engineCallbacks.set(path, callback);
     }
 
     /**
@@ -68,6 +74,12 @@ export class JsonPtrTrie {
         currentNode.getterCallback = getterCallback;
         currentNode.setterCallback = setterCallback;
         currentNode.typeName = typeName;
+    }
+
+    public runEngineCallback(path: string, value: any, onComplete: ()=> void) { 
+        const callback = this.root.engineCallbacks.get(path);
+        if (callback)
+            callback(value, onComplete);
     }
 
     /**

--- a/src/BasicBehaveEngine/decorators/ADecorator.ts
+++ b/src/BasicBehaveEngine/decorators/ADecorator.ts
@@ -12,6 +12,7 @@ export abstract class ADecorator implements IBehaveEngine {
     abstract processAddingNodeToQueue: (flow: IFlow) => void;
     abstract processExecutingNextNode: (flow: IFlow) => void;
     abstract registerKnownPointers: () => void;
+    abstract registerEngineCallback: (path: string, callback: (value: any, onComplete: ()=> void) => void) => void;
     abstract registerJsonPointer: (jsonPtr: string, getterCallback: (path: string) => any, setterCallback: (path: string, value: any) => void, typeName: string) => void;
     abstract animateProperty: (type: string, path: string, easingType: string, easingDuration: number, initialValue: any, targetValue: any, callback: () => void) => void;
 

--- a/src/BasicBehaveEngine/decorators/LoggingDecorator.ts
+++ b/src/BasicBehaveEngine/decorators/LoggingDecorator.ts
@@ -34,6 +34,10 @@ export class LoggingDecorator extends ADecorator {
         this.behaveEngine.registerJsonPointer(jsonPtr, getterCallback, setterCallback, typeName);
     };
 
+    registerEngineCallback = (path: string, callback: (value: any, onComplete: ()=> void) => void) => {
+        this.behaveEngine.registerEngineCallback(path, callback);
+    }
+
     animateProperty = (type: string, path: string, easingType: string, easingDuration: number, initialValue: any, targetValue: any, callback: () => void) => {
         setTimeout(() => {
             this.behaveEngine.setPathValue(path, targetValue);

--- a/src/BasicBehaveEngine/nodes/world/PlayAnimation.ts
+++ b/src/BasicBehaveEngine/nodes/world/PlayAnimation.ts
@@ -1,0 +1,48 @@
+import {BehaveEngineNode, IBehaviourNodeProps} from "../../BehaveEngineNode";
+
+export class PlayAnimation extends BehaveEngineNode {
+    REQUIRED_VALUES = [{id: "animation"}, {id: "speed"}, {id: "loopCount"},  {id: "targetTime"}]
+
+    _animation: number;
+    _speed: number;
+    _loopCount: number;
+    _targetTime: number;
+
+    constructor(props: IBehaviourNodeProps) {
+        super(props);
+        this.name = "PlayAnimation";
+        this.validateValues(this.values);
+        this.validateFlows(this.flows);
+        this.validateConfigurations(this.configuration);
+
+        const {animation, speed, loopCount, targetTime} = this.evaluateAllValues(this.REQUIRED_VALUES.map(val => val.id));
+
+        this._animation = animation;
+        this._speed = speed;
+        this._loopCount = loopCount;
+        this._targetTime = targetTime;
+    }
+
+    override processNode(flowSocket?: string) {
+        this.graphEngine.clearValueEvaluationCache();
+
+        const {animation, speed, loopCount, targetTime} = this.evaluateAllValues(this.REQUIRED_VALUES.map(val => val.id));
+
+        this._animation = animation;
+        this._speed = speed;
+        this._loopCount = loopCount;
+        this._targetTime = targetTime;
+
+        this.graphEngine.processNodeStarted(this);
+
+        console.log("trying to run play animation animation path value");
+        //const storeThisProcessNode = super.processNode;
+        const that = this;
+
+        this.graphEngine.runEngineCallback("playAnimation", {animation, speed, loopCount, targetTime}, function() {
+            if (that.flows.done) {
+                that.addEventToWorkQueue(that.flows.done)
+            }
+        });
+    }
+}

--- a/src/authoring/AuthoringNodeSpecs.ts
+++ b/src/authoring/AuthoringNodeSpecs.ts
@@ -124,6 +124,58 @@ export const worldNodeSpecs: IAuthoringNode[] = [
         }
     },
     {
+        type: "world/playAnimation",
+        description: "Plays animation on the world",
+        configuration: [],
+        input: {
+            flows: [
+                {
+                    id: "in",
+                    description: "The in flow"
+                }
+            ],
+            values: [
+                {
+                    id: "animation",
+                    types: [
+                        "int",
+                    ],
+                    description: "Target animation to run"
+                },
+                {
+                    id: "speed",
+                    types: [
+                        "float",
+                    ],
+                    description: "The speed to run the animation at"
+                },
+                {
+                    id: "loopCount",
+                    types: [
+                        "int",
+                    ],
+                    description: "Counts to loop animation"
+                },
+                {
+                    id: "targetTime",
+                    types: [
+                        "float",
+                    ],
+                    description: "Target time to run."
+                }
+            ]
+        },
+        output: {
+            flows: [
+                {
+                    id: "done",
+                    description: "The out flow"
+                }
+            ],
+            values:[]
+        }
+    },
+    {
         type: "world/animateTo",
         description: "Sets properties of the gltf using JSON pointer over a set time",
         configuration: [

--- a/src/components/engineViews/BabylonEngineComponent.tsx
+++ b/src/components/engineViews/BabylonEngineComponent.tsx
@@ -95,12 +95,6 @@ export const BabylonEngineComponent = (props: {behaveGraphRef: any, setBehaveGra
         const container = await SceneLoader.LoadAssetContainerAsync("", url, sceneRef.current, undefined, ".glb");
         container.addAllToScene();
 
-        // Stop all animations by default (only apply based off of play animation node)
-        for (let i = 0; i < (sceneRef.current?.animationGroups?.length ?? 0); i ++) {
-            sceneRef.current?.animationGroups[i].stop();
-        }
-
-        return buildGlTFNodeLayout(container.rootNodes[0]);
         return {nodes:buildGlTFNodeLayout(container.rootNodes[0]), animations: container.animationGroups};
     };
 


### PR DESCRIPTION
- Added new generalized "engine callback" which includes an arbitrary path and value, as well as a callback for on complete. IE, when the animation is finished, our on complete should be run the next node. Note this path does not reflect a gltf path and can be anything that we want.
- Changed Babylon decorator to go through all nodes and set correct engine callbacks and known pointer functionalities for all transform and animations.
- Fixed animations not clearing when scene reset, and made all animations stopped by default (must define a playAnimation)
- Added play animation node that roughly follows authoring spec

I do believe we may want an instantaneous finish as well as an async finish. Right now, done only reflects the asyc finish.
Also, targetTime is there to reflect the draft spec but has no implementation yet.