### PR TITLE
Fix: stopping or starting an undefined animation should not throw an exception

### DIFF
--- a/src/BasicBehaveEngine/decorators/BabylonDecorator.ts
+++ b/src/BasicBehaveEngine/decorators/BabylonDecorator.ts
@@ -343,7 +343,7 @@ export class BabylonDecorator extends ADecorator {
 
     public stopAnimation = (animationIndex: number): void => {
         const animation: AnimationGroup = this.world.animations[animationIndex]
-        const animationInstance: AnimationGroup = animation.metadata.instance;
+        const animationInstance: AnimationGroup = animation?.metadata?.instance;
         if (animationInstance === undefined) return;
 
         animationInstance.stop();
@@ -353,7 +353,7 @@ export class BabylonDecorator extends ADecorator {
 
     public stopAnimationAt = (animationIndex: number, stopTime: number , callback: () => void): void => {
         const animation: AnimationGroup = this.world.animations[animationIndex]
-        const animationInstance: AnimationGroup = animation.metadata.instance;
+        const animationInstance: AnimationGroup = animation?.metadata?.instance;
         if (animationInstance === undefined) return;
 
         const forward = animationInstance.metadata.isForward;


### PR DESCRIPTION
Currently, when stopping an animation that doesn't exist (e.g. index -1), graph execution stops.  
My understanding is that instead, the `err` flow should be triggered.   

This PR does not add the `err` flow trigger, but makes execution continue instead of throwing an exception.  