### PR TITLE
Deploy currently active branch to GitHub pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [ "initial-work-merge" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: initial-work-merge
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm i --force
+      - name: Build
+        run: npm run build
+        env:
+          # Warnings should not be treated as errors
+          CI: false
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR adds an action to deploy to GitHub pages.

This is currently used in our fork to deploy to https://gltf-interactivity.needle.tools/.

To make it work for this repo,
1. the PR needs to be merged to main (since actions need to be present on the default branch and can then run on any branch)
2. in https://github.com/KhronosGroup/glTF-InteractivityGraph-AuthoringTool/settings/environments/, the github-pages branch needs to be set to `initial-work-merge`
3. in https://github.com/needle-tools/glTF-InteractivityGraph-AuthoringTool/settings/pages, the source needs to be set to `GitHub Actions` (probably the default)

I'm not sure if github.com/KhronosGroup currently has a custom domain setup; if so, there might need to be a CNAME file too pointing at the right domain/subdomain.