### PR TITLE
Add support for receiving different matricies

### DIFF
--- a/src/BasicBehaveEngine/ADecorator.ts
+++ b/src/BasicBehaveEngine/ADecorator.ts
@@ -18,103 +18,103 @@ export abstract class ADecorator implements IBehaveEngine {
     abstract getWorld: () => any;
     abstract getParentNodeIndex: (nodeIndex: number) => number | undefined;
 
-    hoverOn = (nodeIndex: number | undefined, controllerIndex: number) => {
+    hoverOn(nodeIndex: number | undefined, controllerIndex: number) {
         this.behaveEngine.hoverOn(nodeIndex, controllerIndex);
     }
 
-    select = (selectedNodeIndex: number, controllerIndex: number, selectionPoint: [number, number, number] | undefined, selectionRayOrigin: [number, number, number] | undefined) => {
+    select(selectedNodeIndex: number, controllerIndex: number, selectionPoint: [number, number, number] | undefined, selectionRayOrigin: [number, number, number] | undefined) {
         this.behaveEngine.select(selectedNodeIndex, controllerIndex, selectionPoint, selectionRayOrigin);
     }
 
-    getEventList = () => {
+    getEventList() {
         return this.behaveEngine.getEventList();
     }
 
-    clearEventList = () => {
+    clearEventList() {
         this.behaveEngine.clearEventList();
     }
 
-    addEvent = (event: IEventQueueItem) => {
+    addEvent(event: IEventQueueItem) {
         this.behaveEngine.addEvent(event);
     }
 
-    addCustomEventListener = (name: string, func: any) => {
+    addCustomEventListener(name: string, func: any) {
         this.behaveEngine.addCustomEventListener(name, func);
     }
 
-    clearCustomEventListeners = () => {
+    clearCustomEventListeners() {
         this.behaveEngine.clearCustomEventListeners();
     }
 
-    registerBehaveEngineNode = (type: string, behaveEngineNode: typeof BehaveEngineNode) => {
+    registerBehaveEngineNode(type: string, behaveEngineNode: typeof BehaveEngineNode) {
         this.behaveEngine.registerBehaveEngineNode(type, behaveEngineNode);
     }
 
-    isSlerpPath = (path: string): boolean => {
+    isSlerpPath(path: string): boolean {
         return this.behaveEngine.isSlerpPath(path);
     }
-    
-    animateCubicBezier = (path: string, p1: number[], p2: number[], initialValue: any, targetValue: any, duration: number, valueType: string, callback: () => void) => {
+
+    animateCubicBezier(path: string, p1: number[], p2: number[], initialValue: any, targetValue: any, duration: number, valueType: string, callback: () => void) {
         this.behaveEngine.animateCubicBezier(path, p1, p2, initialValue, targetValue, duration, valueType, callback);
     }
 
-    public get fps () : number {
+    public get fps(): number {
         return this.behaveEngine.fps;
     }
 
-    loadBehaveGraph = (behaveGraph: any, runGraph = true) => {
+    loadBehaveGraph(behaveGraph: any, runGraph = true) {
         this.behaveEngine.loadBehaveGraph(behaveGraph, runGraph);
     }
 
-    pauseEventQueue = () => {
+    pauseEventQueue() {
         this.behaveEngine.pauseEventQueue();
     }
 
-    playEventQueue = () => {
+    playEventQueue() {
         this.behaveEngine.playEventQueue();
     }
 
-    dispatchCustomEvent = (name: string, vals: any) => {
+    dispatchCustomEvent(name: string, vals: any) {
         this.behaveEngine.dispatchCustomEvent(name, vals);
     }
 
-    setPathValue = (path: string, targetValue: any) => {
+    setPathValue(path: string, targetValue: any) {
         this.behaveEngine.setPathValue(path, targetValue);
     }
 
-    getPathValue = (path: string) => {
+    getPathValue(path: string) {
         this.behaveEngine.getPathValue(path);
     }
 
-    getPathtypeName = (path: string) => {
+    getPathtypeName(path: string) {
         this.behaveEngine.getPathtypeName(path);
     }
 
-    addEntryToValueEvaluationCache = (key: string, val: IInteractivityValue): void  => {
+    addEntryToValueEvaluationCache(key: string, val: IInteractivityValue): void {
         this.behaveEngine.addEntryToValueEvaluationCache(key, val);
     }
 
-    clearValueEvaluationCache = (): void => {
+    clearValueEvaluationCache(): void {
         this.behaveEngine.clearValueEvaluationCache();
     }
 
-    getValueEvaluationCacheValue = (key: string): IInteractivityValue | undefined => {
+    getValueEvaluationCacheValue(key: string): IInteractivityValue | undefined {
         return this.behaveEngine.getValueEvaluationCacheValue(key);
     }
 
-    setPointerInterpolationCallback = (path: string, action: IInterpolateAction) => {
+    setPointerInterpolationCallback(path: string, action: IInterpolateAction) {
         this.behaveEngine.setPointerInterpolationCallback(path, action);
     }
 
-    clearPointerInterpolation = (path: string) => {
+    clearPointerInterpolation(path: string) {
         this.behaveEngine.clearPointerInterpolation(path);
     }
 
-    setVariableInterpolationCallback = (variable: number, action: IInterpolateAction) => {
+    setVariableInterpolationCallback(variable: number, action: IInterpolateAction) {
         this.behaveEngine.setVariableInterpolationCallback(variable, action);
     }
 
-    clearVariableInterpolation = (variable: number) => {
+    clearVariableInterpolation(variable: number) {
         this.behaveEngine.clearVariableInterpolation(variable);
     }
 }

--- a/src/BasicBehaveEngine/BehaveEngineNode.ts
+++ b/src/BasicBehaveEngine/BehaveEngineNode.ts
@@ -226,7 +226,10 @@ export class BehaveEngineNode {
             case "float3":
                 return [NaN, NaN, NaN];
             case "float4":
+            case "float2x2":
                 return [NaN, NaN, NaN, NaN];
+            case "float3x3":
+                return [NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN];
             case "float4x4":
                 return [NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN];
             default:

--- a/src/BasicBehaveEngine/nodes/customEvent/Receive.ts
+++ b/src/BasicBehaveEngine/nodes/customEvent/Receive.ts
@@ -73,22 +73,35 @@ export class Receive extends BehaveEngineNode {
                 return this.parseMaybeJSON(val[0])
             case "float4":
                 return this.parseMaybeJSON(val[0])
+            case "float2x2":
+                return this.parseMaybeJSON(val[0], 2);
+            case "float3x3":
+                return this.parseMaybeJSON(val[0], 3);
             case "float4x4":
-                return this.parseMaybeJSON(val[0])
+                return this.parseMaybeJSON(val[0], 4);
             default:
                 return val
         }
     }
 
-    parseMaybeJSON(input: any) {
-        if (typeof input === "string") {
+    parseMaybeJSON(input: any, matrixWidth?: number): any {
+        let inputCopy = JSON.parse(JSON.stringify(input));
+        if (typeof inputCopy === "string") {
           try {
-            return JSON.parse(input);
+            inputCopy = JSON.parse(inputCopy);
           } catch (e) {
             throw new Error("Invalid JSON string");
           }
         }
+        if (matrixWidth && Array.isArray(inputCopy) && inputCopy.length === matrixWidth * matrixWidth) {
+            // If the input is a flat array with the correct length, convert it to a 2D array
+            const matrix: number[][] = [];
+            for (let i = 0; i < matrixWidth; i++) {
+                matrix[i] = inputCopy.slice(i * matrixWidth, (i + 1) * matrixWidth);
+            }
+            return matrix;
+        }
         // Already an object/array/etc.
-        return input;
+        return inputCopy;
       }
 }


### PR DESCRIPTION
Previously, float2x2 and float3x3 were not supported properly.
Also, the event/receive node expected matrices as arrays of arrays.
I changed the parser to also allow flattened arrays, which is the format used in the spec. It will now also create deep copies of the input.
Additionally, I changed the function declarations in ADecorator to use functions instead of lambdas. Otherwise, the functions can not easily be overwritten in a child class. Or was this intentional?