### PR TITLE
Fixed Mesh and Material pointers 

### DIFF
--- a/src/decorators/BabylonDecorator.ts
+++ b/src/decorators/BabylonDecorator.ts
@@ -702,8 +702,8 @@ export class BabylonDecorator extends ADecorator {
             const parts: string[] = path.split("/");
             const mesh = this.world.meshes[Number(parts[2])];
             const primitive = mesh.subMeshes[Number(parts[4])];
-            console.log("results", mesh, primitive, this.world.materials.indexOf(primitive.material));
-            return primitive.materialIndex
+            console.log("results", mesh, primitive, this.world.materials.indexOf(primitive._mesh.material));
+            return [this.world.materials.indexOf(primitive._mesh.material)];
         }, (path, value) => {
             const parts: string[] = path.split("/");
             const mesh = this.world.meshes[Number(parts[2])];


### PR DESCRIPTION
Hey, 
there was some bugs in the decorator: 
The pointer getter for /nodes/${maxGltfNode}/mesh and /meshes/${maxGltfNode}/primitives/${maxGltfNode}/material was not returning an array. 
Also the material pointer was accessing the wrong material property of the primitive object. 

And here a test file: 
[20250108-ListTypeWriter.zip](https://github.com/user-attachments/files/23748200/20250108-ListTypeWriter.zip)
