### PR TITLE
Allow progressing the eventQueue manually.

### DIFF
--- a/src/BasicBehaveEngine/ADecorator.ts
+++ b/src/BasicBehaveEngine/ADecorator.ts
@@ -74,6 +74,10 @@ export abstract class ADecorator implements IBehaveEngine {
         this.behaveEngine.playEventQueue();
     }
 
+    executeEventQueueTick() {
+        this.behaveEngine.executeEventQueueTick();
+    }
+
     dispatchCustomEvent(name: string, vals: any) {
         this.behaveEngine.dispatchCustomEvent(name, vals);
     }

--- a/src/BasicBehaveEngine/IBehaveEngine.ts
+++ b/src/BasicBehaveEngine/IBehaveEngine.ts
@@ -128,6 +128,11 @@ export interface IBehaveEngine {
     playEventQueue: () => void;
 
     /**
+     * Executes the engine for one tick. Can be used for manual/renderer controlled stepping.
+     */
+    executeEventQueueTick: () => void;
+
+    /**
      * Emit a custom event with a specified name and values.
      * @param name - The name of the custom event to emit.
      * @param params - The values to be passed to the custom event callback functions.

--- a/src/BasicBehaveEngine/nodes/flow/Throttle.ts
+++ b/src/BasicBehaveEngine/nodes/flow/Throttle.ts
@@ -30,7 +30,7 @@ export class Throttle extends BehaveEngineNode {
                 this.processFlow(this.flows.err);
             }
         } else {
-            const now = Date.now();
+            const now = this.graphEngine.lastTickTime;
             if (!isNaN(this._lastRemainingTime)) {
                 const timeSinceLastCall = now - this._lastSuccessfulCall;
                 if (timeSinceLastCall <= duration * 1000) {

--- a/src/BasicBehaveEngine/nodes/lifecycle/onTick.ts
+++ b/src/BasicBehaveEngine/nodes/lifecycle/onTick.ts
@@ -14,7 +14,7 @@ export class OnTickNode extends BehaveEngineNode {
 
     override processNode(flowSocket?: string) {
         this.graphEngine.processNodeStarted(this);
-        const tickTime = this.graphEngine.lastTickTime;
+        const tickTime = this.graphEngine.lastTickTime / 1000;
         if (isNaN(this._startTime)) {
             this.outValues.timeSinceStart = { value: [0], type: this._floatTypeIndex };
             this.outValues.timeSinceLastTick = { value: [NaN], type: this._floatTypeIndex };

--- a/src/BasicBehaveEngine/nodes/variable/VariableInterpolate.ts
+++ b/src/BasicBehaveEngine/nodes/variable/VariableInterpolate.ts
@@ -45,10 +45,10 @@ export class VariableInterpolate extends BehaveEngineNode {
         }
         const initialValue = this.variables[this._variable].value![0]!;
         const targetValue = value;
-        const startTime = Date.now();
+        const startTime = this.graphEngine.lastTickTime;
 
         const interpolationAction = () => {
-            const elapsedDuration = (Date.now() - startTime) / 1000;
+            const elapsedDuration = (this.graphEngine.lastTickTime - startTime) / 1000;
             const t = Math.min(elapsedDuration / duration, 1);
             const p = cubicBezier(t, {x: 0, y:0}, {x: p1[0], y:p1[1]}, {x: p2[0], y:p2[1]}, {x: 1, y:1});
 


### PR DESCRIPTION
This PR adds the possibility to trigger the `executeEventQueue` function from outside, and not using `setTimout`.
A renderer usually has a render loop where this can be used to e.g. sync between interactivity engine and physics engine.

Additionally, I realized that I did not pause the tick time while pausing the `eventQueue`.
This PR track the paused time and deducts it from tick time to prevent a large time jump after resuming the graph.

I also replaced `Date.now()` with `performance.now()` for more exact timings.
I also generalized the use of tick time. Now the same time is used for `onTick`, interpolation and throttle.