### PR TITLE
added  math/quatSlerp Node

### DIFF
--- a/src/BasicBehaveEngine/BasicBehaveEngine.ts
+++ b/src/BasicBehaveEngine/BasicBehaveEngine.ts
@@ -117,6 +117,7 @@ import { MathSwitch } from "./nodes/math/special/MathSwitch";
 import { Inverse } from "./nodes/math/matrix/Inverse";
 import { DebugLog } from "./nodes/experimental/Debug";
 import { QuatAngleBetween } from "./nodes/math/quaternion/QuatAngleBetween";
+import { QuatFromUpForward } from "./nodes/math/quaternion/QuatFromUpForward";
 import { cubicBezier, linearFloat, slerpFloat4 } from "./easingUtils";
 import { Determinant } from "./nodes/math/matrix/Determinant";
 import { Transform } from "./nodes/math/vector/Transform";
@@ -615,6 +616,7 @@ export class BasicBehaveEngine implements IBehaveEngine {
         this.registerBehaveEngineNode("math/quatAngleBetween", QuatAngleBetween);
         this.registerBehaveEngineNode("math/quatToAxisAngle", QuatToAxisAngle);
         this.registerBehaveEngineNode("math/quatFromDirections", QuatFromDirections);
+        this.registerBehaveEngineNode("math/quatFromUpForward", QuatFromUpForward);
         this.registerBehaveEngineNode("math/matDecompose", MatDecompose);
         this.registerBehaveEngineNode("math/matCompose", MatCompose);
         this.registerBehaveEngineNode("math/determinant", Determinant);

--- a/src/BasicBehaveEngine/BasicBehaveEngine.ts
+++ b/src/BasicBehaveEngine/BasicBehaveEngine.ts
@@ -117,6 +117,7 @@ import { MathSwitch } from "./nodes/math/special/MathSwitch";
 import { Inverse } from "./nodes/math/matrix/Inverse";
 import { DebugLog } from "./nodes/experimental/Debug";
 import { QuatAngleBetween } from "./nodes/math/quaternion/QuatAngleBetween";
+import { QuatSlerp } from "./nodes/math/quaternion/QuatSlerp";
 import { QuatFromUpForward } from "./nodes/math/quaternion/QuatFromUpForward";
 import { cubicBezier, linearFloat, slerpFloat4 } from "./easingUtils";
 import { Determinant } from "./nodes/math/matrix/Determinant";
@@ -614,6 +615,7 @@ export class BasicBehaveEngine implements IBehaveEngine {
         this.registerBehaveEngineNode("math/quatConjugate", QuatConjugate);
         this.registerBehaveEngineNode("math/quatFromAxisAngle", QuatFromAxisAngle);
         this.registerBehaveEngineNode("math/quatAngleBetween", QuatAngleBetween);
+        this.registerBehaveEngineNode("math/quatSlerp", QuatSlerp);
         this.registerBehaveEngineNode("math/quatToAxisAngle", QuatToAxisAngle);
         this.registerBehaveEngineNode("math/quatFromDirections", QuatFromDirections);
         this.registerBehaveEngineNode("math/quatFromUpForward", QuatFromUpForward);

--- a/src/BasicBehaveEngine/nodes/math/quaternion/QuatFromUpForward.ts
+++ b/src/BasicBehaveEngine/nodes/math/quaternion/QuatFromUpForward.ts
@@ -26,10 +26,7 @@ export class QuatFromUpForward extends BehaveEngineNode {
         }
 
         const fwd = glMatrix.vec3.fromValues(forward[0], forward[1], forward[2]);
-        if (glMatrix.vec3.len(fwd) < 1e-6) {
-            throw Error("forward vector must be non-zero");
-        }
-
+    
         const upVec = glMatrix.vec3.fromValues(up[0], up[1], up[2]);
 
         const right = glMatrix.vec3.create();
@@ -53,8 +50,7 @@ export class QuatFromUpForward extends BehaveEngineNode {
 
         const trueUp = glMatrix.vec3.create();
         glMatrix.vec3.cross(trueUp, fwd, right);
-        glMatrix.vec3.normalize(trueUp, trueUp);
-
+     
         const m = glMatrix.mat3.create();
         // Set columns of rotation matrix: right, up, forward
         m[0] = right[0]; m[1] = right[1]; m[2] = right[2];

--- a/src/BasicBehaveEngine/nodes/math/quaternion/QuatFromUpForward.ts
+++ b/src/BasicBehaveEngine/nodes/math/quaternion/QuatFromUpForward.ts
@@ -1,0 +1,71 @@
+import * as glMatrix from "gl-matrix";
+import {BehaveEngineNode, IBehaviourNodeProps} from "../../../BehaveEngineNode";
+
+export class QuatFromUpForward extends BehaveEngineNode {
+    REQUIRED_VALUES = {up: {}, forward: {}}
+
+    constructor(props: IBehaviourNodeProps) {
+        super(props);
+        this.name = "QuatFromUpForwardNode";
+        this.validateValues(this.values);
+    }
+
+    override processNode(flowSocket?: string) {
+        const {up, forward} = this.evaluateAllValues(Object.keys(this.REQUIRED_VALUES));
+        this.graphEngine.processNodeStarted(this);
+        const typeIndexUp = this.values['up'].type!
+        const typeUp: string = this.getType(typeIndexUp);
+        const typeIndexForward = this.values['forward'].type!
+        const typeForward: string = this.getType(typeIndexForward);
+
+        if (typeUp !== "float3") {
+            throw Error(`up should be of type float3, got ${typeUp}`)
+        }
+        if (typeForward !== "float3") {
+            throw Error(`forward should be of type float3, got ${typeForward}`)
+        }
+
+        const fwd = glMatrix.vec3.fromValues(forward[0], forward[1], forward[2]);
+        if (glMatrix.vec3.len(fwd) < 1e-6) {
+            throw Error("forward vector must be non-zero");
+        }
+
+        const upVec = glMatrix.vec3.fromValues(up[0], up[1], up[2]);
+
+        const right = glMatrix.vec3.create();
+        glMatrix.vec3.cross(right, upVec, fwd);
+        if (glMatrix.vec3.len(right) < 1e-6) {
+            // If up and forward are colinear, choose auxiliary axis least aligned with forward
+            const ax = Math.abs(fwd[0]);
+            const ay = Math.abs(fwd[1]);
+            const az = Math.abs(fwd[2]);
+            let arbitrary: glMatrix.vec3;
+            if (ax <= ay && ax <= az) {
+                arbitrary = glMatrix.vec3.fromValues(1, 0, 0);
+            } else if (ay <= ax && ay <= az) {
+                arbitrary = glMatrix.vec3.fromValues(0, 1, 0);
+            } else {
+                arbitrary = glMatrix.vec3.fromValues(0, 0, 1);
+            }
+            glMatrix.vec3.cross(right, arbitrary, fwd);
+        }
+        glMatrix.vec3.normalize(right, right);
+
+        const trueUp = glMatrix.vec3.create();
+        glMatrix.vec3.cross(trueUp, fwd, right);
+        glMatrix.vec3.normalize(trueUp, trueUp);
+
+        const m = glMatrix.mat3.create();
+        // Set columns of rotation matrix: right, up, forward
+        m[0] = right[0]; m[1] = right[1]; m[2] = right[2];
+        m[3] = trueUp[0]; m[4] = trueUp[1]; m[5] = trueUp[2];
+        m[6] = fwd[0];    m[7] = fwd[1];    m[8] = fwd[2];
+
+        const outQ = glMatrix.quat.create();
+        glMatrix.quat.fromMat3(outQ, m);
+        glMatrix.quat.normalize(outQ, outQ);
+
+        const val = [outQ[0], outQ[1], outQ[2], outQ[3]]
+        return {'value': {value: val, type: this.getTypeIndex("float4")}}
+    }
+}

--- a/src/BasicBehaveEngine/nodes/math/quaternion/QuatSlerp.ts
+++ b/src/BasicBehaveEngine/nodes/math/quaternion/QuatSlerp.ts
@@ -1,0 +1,46 @@
+import * as glMatrix from "gl-matrix";
+import { BehaveEngineNode, IBehaviourNodeProps } from "../../../BehaveEngineNode";
+
+export class QuatSlerp extends BehaveEngineNode {
+    REQUIRED_VALUES = { a: {}, b: {}, c: {} }
+
+    constructor(props: IBehaviourNodeProps) {
+        super(props);
+        this.name = "QuatSlerpNode";
+        this.validateValues(this.values);
+    }
+
+    override processNode(flowSocket?: string) {
+        const { a, b, c } = this.evaluateAllValues(Object.keys(this.REQUIRED_VALUES));
+        this.graphEngine.processNodeStarted(this);
+
+        const typeIndexA = this.values['a'].type!;
+        const typeA: string = this.getType(typeIndexA);
+        const typeIndexB = this.values['b'].type!;
+        const typeB: string = this.getType(typeIndexB);
+        const typeIndexC = this.values['c'].type!;
+        const typeC: string = this.getType(typeIndexC);
+
+        if (typeA !== "float4") {
+            throw Error(`a should be of type float4, got ${typeA}`);
+        }
+        if (typeB !== "float4") {
+            throw Error(`b should be of type float4, got ${typeB}`);
+        }
+        if (typeC !== "float") {
+            throw Error(`c should be of type float, got ${typeC}`);
+        }
+
+        const quatA = glMatrix.quat.create();
+        glMatrix.quat.set(quatA, a[0], a[1], a[2], a[3]);
+        const quatB = glMatrix.quat.create();
+        glMatrix.quat.set(quatB, b[0], b[1], b[2], b[3]);
+
+        const result = glMatrix.quat.create();
+        const t = Number(c);
+        glMatrix.quat.slerp(result, quatA, quatB, t);
+
+        const val = [result[0], result[1], result[2], result[3]];
+        return { 'value': { value: val, type: this.getTypeIndex("float4") } };
+    }
+}

--- a/src/BasicBehaveEngine/types/nodes.ts
+++ b/src/BasicBehaveEngine/types/nodes.ts
@@ -435,6 +435,9 @@ export const knownDeclarations: IInteractivityDeclaration[] = [
     },
     {
         op: "math/quatFromDirections"
+    },
+    {
+        op: "math/quatFromUpForward"
     }
 ]
 
@@ -659,6 +662,32 @@ const mathQuaternionNodeSpecs: IInteractivityNode[] = [
                     value: [undefined]
                 },
                 b: {
+                    typeOptions: [4],
+                    type: 4,
+                    value: [undefined]
+                }
+            },
+            output: {
+                value: {
+                    typeOptions: [5],
+                    type: 5,
+                    value: [undefined]
+                }
+            }
+        }
+    },
+    {
+        op: "math/quatFromUpForward",
+        declaration: knownDeclarations.findIndex(declaration => declaration.op === "math/quatFromUpForward"),
+        description: "Create a quaternion from an up vector and a forward direction",
+        values: {
+            input: {
+                up: {
+                    typeOptions: [4],
+                    type: 4,
+                    value: [undefined]
+                },
+                forward: {
                     typeOptions: [4],
                     type: 4,
                     value: [undefined]

--- a/src/BasicBehaveEngine/types/nodes.ts
+++ b/src/BasicBehaveEngine/types/nodes.ts
@@ -438,6 +438,9 @@ export const knownDeclarations: IInteractivityDeclaration[] = [
     },
     {
         op: "math/quatFromUpForward"
+    },
+    {
+        op: "math/quatSlerp"
     }
 ]
 
@@ -690,6 +693,37 @@ const mathQuaternionNodeSpecs: IInteractivityNode[] = [
                 forward: {
                     typeOptions: [4],
                     type: 4,
+                    value: [undefined]
+                }
+            },
+            output: {
+                value: {
+                    typeOptions: [5],
+                    type: 5,
+                    value: [undefined]
+                }
+            }
+        }
+    },
+    {
+        op: "math/quatSlerp",
+        declaration: knownDeclarations.findIndex(declaration => declaration.op === "math/quatSlerp"),
+        description: "Spherical linear interpolation between two quaternions",
+        values: {
+            input: {
+                a: {
+                    typeOptions: [5],
+                    type: 5,
+                    value: [undefined]
+                },
+                b: {
+                    typeOptions: [5],
+                    type: 5,
+                    value: [undefined]
+                },
+                c: {
+                    typeOptions: [2],
+                    type: 2,
                     value: [undefined]
                 }
             },

--- a/tst/nodes.test.ts
+++ b/tst/nodes.test.ts
@@ -122,6 +122,7 @@ import { MathSwitch } from '../src/BasicBehaveEngine/nodes/math/special/MathSwit
 import { DebugLog } from '../src/BasicBehaveEngine/nodes/experimental/Debug';
 import { QuatAngleBetween } from '../src/BasicBehaveEngine/nodes/math/quaternion/QuatAngleBetween';
 import { QuatFromUpForward } from '../src/BasicBehaveEngine/nodes/math/quaternion/QuatFromUpForward';
+import { QuatSlerp } from '../src/BasicBehaveEngine/nodes/math/quaternion/QuatSlerp';
 import * as glMatrix from 'gl-matrix';
 
 describe('nodes', () => {
@@ -2386,6 +2387,24 @@ describe('nodes', () => {
         expect(isCloseToVal(val['value'].value[1], 0.5)).toBe(true);
         expect(isCloseToVal(val['value'].value[2], 0.5)).toBe(true);
         expect(isCloseToVal(val['value'].value[3], 0.5)).toBe(true);
+    });
+
+    it("math/quatSlerp", () => {
+        const quatSlerp: QuatSlerp = new QuatSlerp({
+            ...defaultProps,
+            values: {
+                a: { value: [0, 0, 0, 1], type: 5 },
+                b: { value: [0, 0.7071068, 0, 0.7071068], type: 5 },
+                c: { value: [0.5], type: 2 }
+            }
+        });
+
+        const res = quatSlerp.processNode();
+        const v = res['value'].value;
+        expect(isCloseToVal(v[0], 0.0)).toBe(true);
+        expect(isCloseToVal(v[1], 0.3826834)).toBe(true);
+        expect(isCloseToVal(v[2], 0.0)).toBe(true);
+        expect(isCloseToVal(v[3], 0.9238795)).toBe(true);
     });
 });
 


### PR DESCRIPTION
I added a math/quatSlerp node. 
For the quatFromUpForward sample, the math/mix node was not enough for the quaternions. 
Not sure about the upcoming Slerp spec, so this is mainly meant for testing.

Sample file with quatFromUpForward and quatSlerp:
<img width="993" height="725" alt="image" src="https://github.com/user-attachments/assets/6ca72f73-5659-4c02-b0b5-46a1aa8a5044" />

[LookRotationAndSlerp.zip](https://github.com/user-attachments/files/23796157/LookRotationAndSlerp.zip)

@lexaknyazev Is your plan to add a generic math/slerp node like the mix node, or e special variant for quat, like this draft implementation? 
